### PR TITLE
Fix marker number when deleting notes

### DIFF
--- a/src/imgNotes.js
+++ b/src/imgNotes.js
@@ -251,6 +251,7 @@
  *	Delete a note
  */
 		_delete: function(elem) {
+			this.noteCount--;
 			this.notes = this.notes.filter(function(v) { return v!== elem; });
 			$(elem).off();
 			$(elem).remove();


### PR DESCRIPTION
Now the default marker number decrements correctly when a note is deleted.
